### PR TITLE
Update IP address formatting in YAML configuration

### DIFF
--- a/diyless-thermostat-3.yaml
+++ b/diyless-thermostat-3.yaml
@@ -44,7 +44,7 @@ wifi:
         id: ip_label
         text:
           format: "\uF1EB %s"
-          args: [ 'id(wifi_id).wifi_sta_ip_addresses()[0].str().c_str()' ]
+          args: [ '({ char buf[esphome::network::IP_ADDRESS_BUFFER_SIZE]; id(wifi_id).wifi_sta_ip_addresses()[0].str_to(buf); buf; })' ]
   on_disconnect:
     - lvgl.label.update:
         id: ip_label


### PR DESCRIPTION
On Line 47
Changed:
args: [ 'id(wifi_id).wifi_sta_ip_addresses()[0].str().c_str()' ]

To:
args: [ '({ char buf[esphome::network::IP_ADDRESS_BUFFER_SIZE]; id(wifi_id).wifi_sta_ip_addresses()[0].str_to(buf); buf; })' ]

Due to deprecation of an old approach